### PR TITLE
Fix: Ignore SSL verification errors in requests

### DIFF
--- a/modules/commands.py
+++ b/modules/commands.py
@@ -1,17 +1,34 @@
 import urllib.parse
-
 import requests
 
 from data import payloads, types
 from modules import logger, transform
+from requests.exceptions import SSLError
+from requests.packages.urllib3.exceptions import InsecureRequestWarning
+import warnings
+
+# Suppress the InsecureRequestWarning when SSL verification is disabled
+warnings.simplefilter('ignore', InsecureRequestWarning)
 
 
 def execute(url: str, command: str) -> str:
+    """ 
+        Execute a command on the target system using the specified URL.
+            - Ignores SSL verification errors
+    """
+    
     if "SHELL" not in url:
         logger.log("Invalid URL. Please make sure the formatting is correct.")
         exit()
     command_string = url.replace("SHELL", command)
-    data = requests.get(command_string)
+    try:
+        # Attempt to make the request with SSL verification
+        data = requests.get(command_string)
+    except SSLError:
+        # If an SSL error occurs, retry the request with SSL verification disabled
+        logger.log("SSL verification failed. Retrying with verify=False.")
+        data = requests.get(command_string, verify=False)
+
     return data.text
 
 

--- a/modules/commands.py
+++ b/modules/commands.py
@@ -1,22 +1,23 @@
 import urllib.parse
+import warnings
+
 import requests
+from requests.exceptions import SSLError
+from requests.packages.urllib3.exceptions import InsecureRequestWarning
 
 from data import payloads, types
 from modules import logger, transform
-from requests.exceptions import SSLError
-from requests.packages.urllib3.exceptions import InsecureRequestWarning
-import warnings
 
 # Suppress the InsecureRequestWarning when SSL verification is disabled
-warnings.simplefilter('ignore', InsecureRequestWarning)
+warnings.simplefilter("ignore", InsecureRequestWarning)
 
 
 def execute(url: str, command: str) -> str:
-    """ 
-        Execute a command on the target system using the specified URL.
-            - Ignores SSL verification errors
     """
-    
+    Execute a command on the target system using the specified URL.
+        - Ignores SSL verification errors
+    """
+
     if "SHELL" not in url:
         logger.log("Invalid URL. Please make sure the formatting is correct.")
         exit()


### PR DESCRIPTION
- Disabled SSL verification for requests that encounter SSL verification errors.
- Added handling to suppress warnings related to insecure HTTPS requests.